### PR TITLE
添加3.2.5的更新

### DIFF
--- a/Native/native/hotUpdate/README.md
+++ b/Native/native/hotUpdate/README.md
@@ -163,6 +163,13 @@ iOS:
 options[@OPTION_PUBLISH_ZIP] = @"game_code.zip";
 ~~~
 
+## 不进行热更新仍然显示GameLoadingView的方法（Android support 3.2.5添加）
+
+在设置GameLoadingView时添加最短持续时间的参数:
+~~~
+gameEngine.game_engine_set_loading_view(new GameLoadingView(this), 5); // GameLoadingView将最少持续5秒
+~~~
+
 ## 总结
 
 热更新的机制比较简单。基本就几步：


### PR DESCRIPTION
3.2.5添加了设置GameLoadingView最短持续时间的接口，用于修复3.2.4中出现的不进行热更新时不出现GameLoadingView的问题